### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["**"]


### PR DESCRIPTION
Potential fix for [https://github.com/wzshiming/xet-go/security/code-scanning/1](https://github.com/wzshiming/xet-go/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or per job) that grants only the minimal scopes required. For this CI job, it checks out code, sets up languages, builds, runs tests, and uses the cache action. None of these require write access to repository contents, issues, or pull requests. The minimal and appropriate permissions are therefore `contents: read`, which also suffices for the cache keys and standard actions being used.

The simplest way to fix this without changing functionality is to add a root-level `permissions` block just under the `name: CI` line (before `on:`). This will apply to all jobs that don’t override `permissions`, which currently includes `build-and-test`. The block should specify `contents: read`. There is no need for additional scopes such as `packages` or `pull-requests` based on the shown steps. No imports, methods, or additional files are needed; only this YAML edit in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
